### PR TITLE
Fix issue where sprite doesn't match cursor

### DIFF
--- a/webpage/script.js
+++ b/webpage/script.js
@@ -120,6 +120,7 @@ let changeSpr = e => {
 
 	// Refresh cursor
 	canvas.style.cursor = `url(${sprites[arrSelect][0]}), auto`;
+	sprSelect = 0;
 }
 
 // Listen for when the menu buttons are clicked. Switch selected array accordingly.


### PR DESCRIPTION
Fix issue where the sprite doesn't match the cursor once the 'characters' or 'terrain' buttons are pressed.